### PR TITLE
Refactor: add class field defaults

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -38,27 +38,27 @@ const icon = ""; //"⌨ ";
 const opening = ""; //"_";
 const closing = ""; //"_";
 
-//TODO: eliminate global variables
-let seat;
-let button,
-    label;
-
-let state,
-    prev_state,
-    latch,
-    prev_latch,
-    lock,
-    prev_lock;
-
-let indicator;
-
-let timeout_id,
-    mods_update_id;
 
 // Gnome-shell extension interface
 // init, enable, disable
 
 export default class KMS extends Extension {
+
+    seat = null;
+    button = null;
+    label = null;
+
+    state = 0;
+    prev_state = 0;
+    latch = 0;
+    prev_latch = 0;
+    lock = 0;
+    prev_lock = 0;
+
+    indicator = null;
+
+    timeout_id = null;
+    mods_update_id = null;
 
 
     constructor(metadata) {
@@ -70,46 +70,47 @@ export default class KMS extends Extension {
     enable() {
         console.debug(`${tag} enable() ... in`);
 
-        //
+        // Initialize properties
+        this.seat = null;
+        this.button = null;
+        this.label = null;
 
-        seat = null;
-        button = null;
-        label = null;
+        this.state = 0;
+        this.prev_state = 0;
+        this.latch = 0;
+        this.prev_latch = 0;
+        this.lock = 0;
+        this.prev_lock = 0;
 
-        state = 0;
-        prev_state = 0;
-        latch = 0;
-        prev_latch = 0;
-        lock = 0;
-        prev_lock = 0;
+        this.indicator = null;
 
-        timeout_id = null;
-        mods_update_id = null;
+        this.timeout_id = null;
+        this.mods_update_id = null;
 
-        //
-        button = new St.Bin({ style_class: 'panel-button',
+        // Create UI elements
+        this.button = new St.Bin({ style_class: 'panel-button',
             reactive: false,
             can_focus: false,
             x_expand: true,
             y_expand: false,
             track_hover: false });
-        label = new St.Label({ style_class: "state-label", text: "" });
-        button.set_child(label);
+        this.label = new St.Label({ style_class: "state-label", text: "" });
+        this.button.set_child(this.label);
 
         //console.debug(`${tag} Running Wayland: ` + Meta.is_wayland_compositor());
 
         try {
-            seat = Clutter.get_default_backend().get_default_seat();
+            this.seat = Clutter.get_default_backend().get_default_seat();
         } catch (e) {
-            seat = Clutter.DeviceManager.get_default();
+            this.seat = Clutter.DeviceManager.get_default();
         };
 
-        if (seat) {
-            mods_update_id = seat.connect("kbd-a11y-mods-state-changed", this._a11y_mods_update);
+        if (this.seat) {
+            this.mods_update_id = this.seat.connect("kbd-a11y-mods-state-changed", this._a11y_mods_update.bind(this));
         };
 
-        Main.panel._rightBox.insert_child_at_index(button, 0);
-        timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, this._update);
+        Main.panel._rightBox.insert_child_at_index(this.button, 0);
+        this.timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, this._update.bind(this));
 
         console.debug(`${tag} enable() ... out`);
     }
@@ -118,23 +119,32 @@ export default class KMS extends Extension {
     disable() {
         console.debug(`${tag} disable() ... in`);
 
-        Main.panel._rightBox.remove_child(button);
+        Main.panel._rightBox.remove_child(this.button);
 
-        GLib.source_remove(timeout_id);
+        GLib.source_remove(this.timeout_id);
 
-        if (seat && mods_update_id) {
-            seat.disconnect(mods_update_id);
+        if (this.seat && this.mods_update_id) {
+            this.seat.disconnect(this.mods_update_id);
         };
 
-        button.destroy_all_children();
-        button.destroy();
+        this.button.destroy_all_children();
+        this.button.destroy();
 
-        seat = null;
-        button = null;
-        label = null;
+        this.seat = null;
+        this.button = null;
+        this.label = null;
 
-        timeout_id = null;
-        mods_update_id = null;
+        this.state = 0;
+        this.prev_state = 0;
+        this.latch = 0;
+        this.prev_latch = 0;
+        this.lock = 0;
+        this.prev_lock = 0;
+
+        this.indicator = null;
+
+        this.timeout_id = null;
+        this.mods_update_id = null;
 
         console.debug(`${tag} disable() ... out`);
     }
@@ -149,40 +159,40 @@ export default class KMS extends Extension {
         // is the effective
 
         const [x, y, m] = global.get_pointer();
-        
+
         if (typeof m !== 'undefined') {
-            state = m;
+            this.state = m;
         };
 
-        if ((state != prev_state) || latch != prev_latch || lock != prev_lock) {
-            console.debug(`${tag} State changed... ${prev_state}, ${state}`);
-            indicator = icon + opening + " ";
+        if ((this.state != this.prev_state) || this.latch != this.prev_latch || this.lock != this.prev_lock) {
+            console.debug(`${tag} State changed... ${this.prev_state}, ${this.state}`);
+            this.indicator = icon + opening + " ";
             //TODO: don't relay on internal order
             //      use standard pre-defined constant masks
             for (var i=0; i<8; i++ ) {
-                if ((state & 1<<i) || (lock & 1<<i)) {
-                    indicator += mod_sym[i];
+                if ((this.state & 1<<i) || (this.lock & 1<<i)) {
+                    this.indicator += mod_sym[i];
                 } else {
                     //indicator += "";
                 };
-                if (latch & 1<<i) {
-                    indicator += latch_sym + " ";
+                if (this.latch & 1<<i) {
+                    this.indicator += latch_sym + " ";
                 } else {
                     //indicator += "";
                 };
-                if (lock & 1<<i) {
-                    indicator += lock_sym + " ";
+                if (this.lock & 1<<i) {
+                    this.indicator += lock_sym + " ";
                 } else {
                     //indicator += "";
                 };
             }
-            indicator += " " + closing;
+            this.indicator += " " + closing;
 
-            label.text = indicator;
+            this.label.text = this.indicator;
 
-            prev_state = state;
-            prev_latch = latch;
-            prev_lock = lock;
+            this.prev_state = this.state;
+            this.prev_latch = this.latch;
+            this.prev_lock = this.lock;
         }
 
         console.debug(`${tag} _update() ... out`);
@@ -195,12 +205,12 @@ export default class KMS extends Extension {
         console.debug(`${tag} _a11y_mods_update() ... in`);
         //TODO: search what's the 1st parameter
         if (typeof latch_new !== 'undefined') {
-            latch = latch_new;
+            this.latch = latch_new;
         };
         if (typeof lock_new !== 'undefined') {
-            lock = lock_new;
+            this.lock = lock_new;
         };
-        console.debug(`${tag} latch: ${latch}, lock: ${lock}`);
+        console.debug(`${tag} latch: ${this.latch}, lock: ${this.lock}`);
         console.debug(`${tag} _a11y_mods_update() ... out`);
         //return true;
         return GLib.SOURCE_CONTINUE;


### PR DESCRIPTION
## Summary
- add former globals as class fields with default values for readability

## Testing
- `make test` *(fails: gjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844845e98b083328f4dba46d0192960