### PR TITLE
Add configurable display symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 package/
+schemas/gschemas.compiled

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ build:
 install:
 	mkdir -p ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/
 	cp ./*.js* ./*.css ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/
+	mkdir -p ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
+	cp schemas/*.gschema.xml ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
+	glib-compile-schemas ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
 
 test: test-js
 
@@ -25,7 +28,10 @@ dist-clean:
 
 dist: dist-clean
 	mkdir -p package
-	zip -j package/keyboard_modifiers_status@sneetsher.zip ./*.js* ./*.css
+	glib-compile-schemas schemas
+	zip -j package/keyboard_modifiers_status@sneetsher.zip \
+./*.js* ./*.css schemas/*.gschema.xml schemas/gschemas.compiled
+	rm schemas/gschemas.compiled
 
 test-js:
 	gjs ./lab/test_gjs_gdk_modifiers.js

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Choose a method
             unzip keyboard_modifiers_status@sneetsher.zip -d ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher
 
         or
-            
+
             make install
     
     2. Restart gnome-shell, using <kbd>Alt</kbd>+<kbd>F2</kbd> then `r`+<kbd>Enter</kbd> with Xorg or logout/login with Wayland.
@@ -33,6 +33,8 @@ Choose a method
 
 
 ## Extras
+
+- The preferences window allows customizing modifier mappings and display symbols.
 
 - Enable an extension for all users (machine-wide)
 

--- a/extension.js
+++ b/extension.js
@@ -58,24 +58,24 @@ let closing = ""; //"_";
 // constructor, enable, disable
 export default class KMS extends Extension {
 
+    state = 0;
+    prev_state = null;
+    latch = 0;
+    prev_latch = null;
+    lock = 0;
+    prev_lock = null;
+
+    indicator = null;
+
     seat = null;
     button = null;
     label = null;
 
-    state = 0;
-    prev_state = null;
-    latch = 0;
-    prev_latch = 0;
-    lock = 0;
-    prev_lock = 0;
-
-    indicator = null;
-
-    timeout_id = null;
-    mods_update_id = null;
     settings = null;
     settingsChangedId = null;
 
+    mods_update_id = null;
+    timeout_id = null;
 
     constructor(metadata) {
         super(metadata);
@@ -86,22 +86,14 @@ export default class KMS extends Extension {
     enable() {
         console.debug(`${tag} enable() ... in`);
 
-        // Initialize properties
-        this.seat = null;
-        this.button = null;
-        this.label = null;
-
         this.state = 0;
         this.prev_state = null;
         this.latch = 0;
-        this.prev_latch = 0;
+        this.prev_latch = null;
         this.lock = 0;
-        this.prev_lock = 0;
+        this.prev_lock = null;
 
         this.indicator = null;
-
-        this.timeout_id = null;
-        this.mods_update_id = null;
 
         this.settings = this.getSettings();
         this._loadSettings();
@@ -120,6 +112,7 @@ export default class KMS extends Extension {
             track_hover: false });
         this.label = new St.Label({ style_class: "state-label", text: "" });
         this.button.set_child(this.label);
+        Main.panel._rightBox.insert_child_at_index(this.button, 0);
 
         //console.debug(`${tag} Running Wayland: ` + Meta.is_wayland_compositor());
 
@@ -133,7 +126,6 @@ export default class KMS extends Extension {
             this.mods_update_id = this.seat.connect("kbd-a11y-mods-state-changed", this._a11y_mods_update.bind(this));
         };
 
-        Main.panel._rightBox.insert_child_at_index(this.button, 0);
         this.timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, this._update.bind(this));
 
         console.debug(`${tag} enable() ... out`);
@@ -143,37 +135,43 @@ export default class KMS extends Extension {
     disable() {
         console.debug(`${tag} disable() ... in`);
 
-        Main.panel._rightBox.remove_child(this.button);
+        if (this.timeout_id) {
+            GLib.source_remove(this.timeout_id);
+            this.timeout_id = null;
+        }
 
-        GLib.source_remove(this.timeout_id);
-
-        if (this.seat && this.mods_update_id) {
-            this.seat.disconnect(this.mods_update_id);
+        if (this.seat) {
+            if (this.mods_update_id) {
+                this.seat.disconnect(this.mods_update_id);
+                this.mods_update_id = null;
+            }
+            this.seat = null;
         };
 
-        this.button.destroy_all_children();
-        this.button.destroy();
+        if (this.button) {
+            Main.panel._rightBox.remove_child(this.button);
+            this.button.destroy_all_children();
+            this.button.destroy();
+            this.button = null;
+            this.label = null;
+        }
 
-        this.seat = null;
-        this.button = null;
-        this.label = null;
+        if (this.settings) {
+            if (this.settingsChangedId) {
+                this.settings.disconnect(this.settingsChangedId);
+                this.settingsChangedId = null;
+            }
+            this.settings = null;
+        }
+
+        this.indicator = null;
 
         this.state = 0;
         this.prev_state = null;
         this.latch = 0;
-        this.prev_latch = 0;
+        this.prev_latch = null;
         this.lock = 0;
-        this.prev_lock = 0;
-
-        this.indicator = null;
-
-        this.timeout_id = null;
-        this.mods_update_id = null;
-        if (this.settings && this.settingsChangedId) {
-            this.settings.disconnect(this.settingsChangedId);
-        }
-        this.settings = null;
-        this.settingsChangedId = null;
+        this.prev_lock = null;
 
         console.debug(`${tag} disable() ... out`);
     }
@@ -185,6 +183,7 @@ export default class KMS extends Extension {
             console.warning(`${tag} this.settings is null`);
             return;
         }
+
         MODIFIERS = [
             [MODIFIER_ENUM.SHIFT, this.settings.get_string('shift-symbol')],
             [MODIFIER_ENUM.LOCK, this.settings.get_string('caps-symbol')],

--- a/metadata.json
+++ b/metadata.json
@@ -11,5 +11,6 @@
 	"name": "Keyboard Modifiers Status",
 	"description": "Shows keyboard modifiers status. It's useful when sticky keys are active.",
 	"original-author": "sneetsher@localhost",
-	"url": "https://github.com/sneetsher/Keyboard-Modifiers-Status"
+        "url": "https://github.com/sneetsher/Keyboard-Modifiers-Status",
+        "settings-schema": "org.gnome.shell.extensions.keyboard-modifiers-status"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,0 +1,100 @@
+import Gtk from 'gi://Gtk';
+import Adw from 'gi://Adw';
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+const tag = 'KMS-Ext-Prefs:';
+
+export default class Prefs extends ExtensionPreferences {
+    constructor(metadata) {
+        super(metadata);
+
+        this.settings = this.getSettings();
+        this.settingsSchema = this.settings.settings_schema;
+
+        this.groupEntries = {};
+    }
+
+    fillPreferencesWindow(window) {
+        console.debug(`${tag} fillPreferencesWindow() ... in`);
+        const page = new Adw.PreferencesPage();
+
+        const modifiersGroup = new Adw.PreferencesGroup({ title: 'Modifier Mapping' });
+        const symbolsGroup = new Adw.PreferencesGroup({ title: 'Symbols' });
+
+        const modifiersKeys = ['shift-symbol', 'caps-symbol', 'control-symbol', 'mod1-symbol', 'mod2-symbol', 'mod3-symbol', 'mod4-symbol', 'mod5-symbol'];
+        modifiersKeys.forEach(k => {
+            const schemaKey = this.settingsSchema.get_key(k);
+            if (!schemaKey) {
+                console.warn(`${tag} modifier key "${k}" doesn't exist in schema`);
+                return;
+            }
+
+            this.addGroupEntry(modifiersGroup, k, schemaKey.get_summary());
+        });
+
+        const symbolsKeys = ['latch-symbol', 'lock-symbol', 'icon', 'opening', 'closing'];
+        symbolsKeys.forEach(k => {
+            const schemaKey = this.settingsSchema.get_key(k);
+            if (!schemaKey) {
+                console.warn(`${tag} symbol key "${k}" doesn't exist in schema`);
+                return;
+            }
+
+            this.addGroupEntry(symbolsGroup, k, schemaKey.get_summary());
+        });
+
+        const macDefaults = ['⇧', '⇬', '⋀', '⌥', '①', '◆', '⌘', '⎇'];
+        const pcDefaults = ['⇧', '⇪', '⌃', '⎇', '⇭', '⇳', '❖', '⎈'];
+
+        const resetRow = new Adw.ActionRow({ title: 'Reset to defaults' });
+        const macButton = new Gtk.Button({ label: 'Mac' });
+        const pcButton = new Gtk.Button({ label: 'PC' });
+        const resetModifiers = (defaults) => {
+            modifiersKeys.forEach((k, i) => {
+                if (this.groupEntries[k]) {
+                    this.groupEntries[k].text = defaults[i];
+                    this.settings.set_string(k, defaults[i]);
+                }
+            });
+        }
+        macButton.connect('clicked', () => resetModifiers(macDefaults));
+        pcButton.connect('clicked', () => resetModifiers(pcDefaults));
+        resetRow.add_suffix(macButton);
+        resetRow.add_suffix(pcButton);
+        modifiersGroup.add(resetRow);
+
+        page.add(modifiersGroup);
+        page.add(symbolsGroup);
+
+        window.add(page);
+        window.show();
+
+        console.debug(`${tag} fillPreferencesWindow() ... out`);
+    }
+
+    addGroupEntry(group, key, title) {
+        if (this.groupEntries[key]) {
+            console.warn(`${tag} addGroupEntry: duplicate key: ${key}`);
+            return;
+        }
+        const entry = new Gtk.Entry({ text: this.settings.get_string(key) });
+        entry.connect('changed', () => {
+            this.settings.set_string(key, entry.text);
+        });
+        this.settings.connect(`changed::${key}`, () => {
+            const val = this.settings.get_string(key);
+            if (entry.text !== val) entry.text = val;
+        });
+        this.groupEntries[key] = entry;
+
+        const row = new Adw.ActionRow({ title });
+        row.add_suffix(entry);
+        row.activatable_widget = entry;
+
+        group.add(row);
+    };
+}
+
+export function init() {
+    return new Prefs();
+}

--- a/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.keyboard-modifiers-status" path="/org/gnome/shell/extensions/keyboard-modifiers-status/">
+    <key name="shift-symbol" type="s">
+      <default>'⇧'</default>
+      <summary>Shift symbol</summary>
+      <description>Symbol displayed when the Shift modifier is active.</description>
+    </key>
+    <key name="caps-symbol" type="s">
+      <default>'⇬'</default>
+      <summary>Caps Lock symbol</summary>
+      <description>Symbol displayed when the Caps Lock modifier is active.</description>
+    </key>
+    <key name="control-symbol" type="s">
+      <default>'⋀'</default>
+      <summary>Control symbol</summary>
+      <description>Symbol displayed when the Control modifier is active.</description>
+    </key>
+    <key name="mod1-symbol" type="s">
+      <default>'⌥'</default>
+      <summary>Mod1/Alt symbol</summary>
+      <description>Symbol displayed when the Mod1/Alt modifier is active.</description>
+    </key>
+    <key name="mod2-symbol" type="s">
+      <default>'①'</default>
+      <summary>Mod2/Num Lock symbol</summary>
+			<description>Symbol displayed when the Mod2/Num Lock modifier is active.</description>
+    </key>
+    <key name="mod3-symbol" type="s">
+      <default>'◆'</default>
+			<summary>Mod3/Scroll Lock symbol</summary>
+			<description>Symbol displayed when the Mod3/Scroll Lock modifier is active.</description>
+    </key>
+    <key name="mod4-symbol" type="s">
+      <default>'⌘'</default>
+			<summary>Mod4/Super symbol</summary>
+      <description>Symbol displayed when the Mod4/Super modifier is active.</description>
+    </key>
+    <key name="mod5-symbol" type="s">
+      <default>'⎇'</default>
+      <summary>Mod5/AltGr symbol</summary>
+			<description>Symbol displayed when the Mod5/AltGr modifier is active.</description>
+    </key>
+    <key name="latch-symbol" type="s">
+      <default>'\''</default>
+      <summary>Latch symbol</summary>
+      <description>Symbol displayed when a modifier is latched.</description>
+    </key>
+    <key name="lock-symbol" type="s">
+      <default>'◦'</default>
+      <summary>Lock symbol</summary>
+      <description>Symbol displayed when a modifier is locked.</description>
+    </key>
+    <key name="icon" type="s">
+      <default>''</default>
+      <summary>Prefix icon</summary>
+      <description>Optional symbol shown before the modifier list.</description>
+    </key>
+    <key name="opening" type="s">
+      <default>''</default>
+      <summary>Opening text</summary>
+      <description>String placed before the modifier state display.</description>
+    </key>
+    <key name="closing" type="s">
+      <default>''</default>
+      <summary>Closing text</summary>
+      <description>String placed after the modifier state display.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
## Summary
- make modifier display symbols configurable
- load new keys from GSettings in the extension
- expose new options in prefs UI
- document customization via preferences

## Testing
- `glib-compile-schemas schemas`
- `make test-js` *(fails: gjs missing)*

------
https://chatgpt.com/codex/tasks/task_e_684875da9de483328b5b57d0e7186f1d