### PR TITLE
Fix settings loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 package/
+schemas/gschemas.compiled

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ build:
 install:
 	mkdir -p ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/
 	cp ./*.js* ./*.css ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/
+	mkdir -p ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
+	cp schemas/*.gschema.xml ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
+	glib-compile-schemas ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher/schemas
 
 test: test-js
 
@@ -25,7 +28,10 @@ dist-clean:
 
 dist: dist-clean
 	mkdir -p package
-	zip -j package/keyboard_modifiers_status@sneetsher.zip ./*.js* ./*.css
+	glib-compile-schemas schemas
+	zip -j package/keyboard_modifiers_status@sneetsher.zip \
+./*.js* ./*.css schemas/*.gschema.xml schemas/gschemas.compiled
+	rm schemas/gschemas.compiled
 
 test-js:
 	gjs ./lab/test_gjs_gdk_modifiers.js

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Choose a method
             unzip keyboard_modifiers_status@sneetsher.zip -d ~/.local/share/gnome-shell/extensions/keyboard_modifiers_status@sneetsher
 
         or
-            
+
             make install
     
     2. Restart gnome-shell, using <kbd>Alt</kbd>+<kbd>F2</kbd> then `r`+<kbd>Enter</kbd> with Xorg or logout/login with Wayland.
@@ -33,6 +33,8 @@ Choose a method
 
 
 ## Extras
+
+- The preferences window allows customizing modifier mappings and display symbols.
 
 - Enable an extension for all users (machine-wide)
 

--- a/extension.js
+++ b/extension.js
@@ -28,23 +28,23 @@ import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const tag = "KMS-Ext:";
 
-//TODO: convert into preferrence.
-// Mapping of modifier masks to the displayed symbol
-const MODIFIERS = [
-    [Clutter.ModifierType.SHIFT_MASK, '⇧'],
-    [Clutter.ModifierType.LOCK_MASK, '⇬'],
-    [Clutter.ModifierType.CONTROL_MASK, '⋀'],
-    [Clutter.ModifierType.MOD1_MASK, '⌥'],
-    [Clutter.ModifierType.MOD2_MASK, '①'],
-    [Clutter.ModifierType.MOD3_MASK, '◆'],
-    [Clutter.ModifierType.MOD4_MASK, '⌘'],
-    [Clutter.ModifierType.MOD5_MASK, '⎇'],
-];
-const latch_sym = "'";
-const lock_sym = "◦";
-const icon = ""; //"⌨ ";
-const opening = ""; //"_";
-const closing = ""; //"_";
+const MODIFIER_ENUM = {
+    SHIFT: Clutter.ModifierType.SHIFT_MASK,
+    LOCK: Clutter.ModifierType.LOCK_MASK,
+    CONTROL: Clutter.ModifierType.CONTROL_MASK,
+    MOD1: Clutter.ModifierType.MOD1_MASK,
+    MOD2: Clutter.ModifierType.MOD2_MASK,
+    MOD3: Clutter.ModifierType.MOD3_MASK,
+    MOD4: Clutter.ModifierType.MOD4_MASK,
+    MOD5: Clutter.ModifierType.MOD5_MASK,
+};
+
+let MODIFIERS = [];
+let latch_sym = "'";
+let lock_sym = "◦";
+let icon = ""; //"⌨ ";
+let opening = ""; //"_";
+let closing = ""; //"_";
 
 
 // Gnome-shell extension interface
@@ -93,6 +93,19 @@ export default class KMS extends Extension {
 
         this.timeout_id = null;
         this.mods_update_id = null;
+
+        const settings = this.getSettings();
+        MODIFIERS = [];
+        for (const item of settings.get_strv('modifier-mapping')) {
+            const [name, sym] = item.split(':');
+            if (MODIFIER_ENUM[name])
+                MODIFIERS.push([MODIFIER_ENUM[name], sym]);
+        }
+        latch_sym = settings.get_string('latch-symbol');
+        lock_sym = settings.get_string('lock-symbol');
+        icon = settings.get_string('icon');
+        opening = settings.get_string('opening');
+        closing = settings.get_string('closing');
 
         // Create UI elements
         this.button = new St.Bin({ style_class: 'panel-button',

--- a/metadata.json
+++ b/metadata.json
@@ -11,5 +11,6 @@
 	"name": "Keyboard Modifiers Status",
 	"description": "Shows keyboard modifiers status. It's useful when sticky keys are active.",
 	"original-author": "sneetsher@localhost",
-	"url": "https://github.com/sneetsher/Keyboard-Modifiers-Status"
+        "url": "https://github.com/sneetsher/Keyboard-Modifiers-Status",
+        "settings-schema": "org.gnome.shell.extensions.keyboard-modifiers-status"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,0 +1,58 @@
+import Gtk from 'gi://Gtk';
+import Adw from 'gi://Adw';
+import {ExtensionPreferences} from 'resource:///org/gnome/shell/extensions/prefs.js';
+
+export default class Prefs extends ExtensionPreferences {
+    constructor(metadata) {
+        super(metadata);
+        this.settings = this.getSettings();
+    }
+
+    fillPreferencesWindow(window) {
+        const page = new Adw.PreferencesPage();
+        const group = new Adw.PreferencesGroup({ title: 'Modifier Mapping' });
+
+        const textView = new Gtk.TextView({ monospace: true });
+        const buffer = textView.get_buffer();
+        buffer.text = this.settings.get_strv('modifier-mapping').join('\n');
+        buffer.connect('changed', () => {
+            const text = buffer.text;
+            const lines = text.split('\n').map(l => l.trim()).filter(l => l);
+            this.settings.set_strv('modifier-mapping', lines);
+        });
+
+        const scrolled = new Gtk.ScrolledWindow({ hexpand: true, vexpand: true });
+        scrolled.set_child(textView);
+
+        const row = new Adw.ActionRow({ title: 'Mappings' });
+        row.add(scrolled);
+        group.add(row);
+        page.add(group);
+
+        const symbols = new Adw.PreferencesGroup({ title: 'Symbols' });
+        const addEntry = (key, title) => {
+            const entry = new Gtk.Entry({ text: this.settings.get_string(key) });
+            entry.connect('changed', () => {
+                this.settings.set_string(key, entry.text);
+            });
+            const r = new Adw.ActionRow({ title });
+            r.add_suffix(entry);
+            r.activatable_widget = entry;
+            symbols.add(r);
+        };
+
+        addEntry('latch-symbol', 'Latch symbol');
+        addEntry('lock-symbol', 'Lock symbol');
+        addEntry('icon', 'Icon');
+        addEntry('opening', 'Opening');
+        addEntry('closing', 'Closing');
+
+        page.add(symbols);
+        window.add(page);
+        window.show();
+    }
+}
+
+export function init() {
+    return new Prefs();
+}

--- a/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.keyboard-modifiers-status" path="/org/gnome/shell/extensions/keyboard-modifiers-status/">
+    <key name="modifier-mapping" type="as">
+      <default>
+        ['SHIFT:⇧', 'LOCK:⇬', 'CONTROL:⋀', 'MOD1:⌥', 'MOD2:①', 'MOD3:◆', 'MOD4:⌘', 'MOD5:⎇']
+      </default>
+      <summary>Modifier symbol mapping</summary>
+      <description>Array mapping modifier names to symbols using NAME:SYMBOL format.</description>
+    </key>
+    <key name="latch-symbol" type="s">
+      <default>'\''</default>
+      <summary>Latch symbol</summary>
+      <description>Symbol displayed when a modifier is latched.</description>
+    </key>
+    <key name="lock-symbol" type="s">
+      <default>'◦'</default>
+      <summary>Lock symbol</summary>
+      <description>Symbol displayed when a modifier is locked.</description>
+    </key>
+    <key name="icon" type="s">
+      <default>''</default>
+      <summary>Prefix icon</summary>
+      <description>Optional symbol shown before the modifier list.</description>
+    </key>
+    <key name="opening" type="s">
+      <default>''</default>
+      <summary>Opening text</summary>
+      <description>String placed before the modifier state display.</description>
+    </key>
+    <key name="closing" type="s">
+      <default>''</default>
+      <summary>Closing text</summary>
+      <description>String placed after the modifier state display.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
## Summary
- initialize settings using Extension base methods
- update preferences to extend ExtensionPreferences

## Testing
- `glib-compile-schemas schemas`
- `make test-js` *(fails: gjs missing)*

------
https://chatgpt.com/codex/tasks/task_e_684875da9de483328b5b57d0e7186f1d