### PR TITLE
Fix preferences window for GNOME 48

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -25,7 +25,7 @@ export default class Prefs extends ExtensionPreferences {
         scrolled.set_child(textView);
 
         const row = new Adw.ActionRow({ title: 'Mappings' });
-        row.add(scrolled);
+        row.set_child(scrolled);
         group.add(row);
         page.add(group);
 
@@ -48,7 +48,7 @@ export default class Prefs extends ExtensionPreferences {
         addEntry('closing', 'Closing');
 
         page.add(symbols);
-        window.add(page);
+        window.set_child(page);
         window.show();
     }
 }


### PR DESCRIPTION
## Summary
- fix loading extension preferences on GNOME 48 by using `set_child`

## Testing
- `make test-js` *(fails: Failed to open display)*

------
https://chatgpt.com/codex/tasks/task_e_684b485351c08332bf4bb69d9fcefede