### PR TITLE
Split modifier mapping

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -102,12 +102,16 @@ export default class KMS extends Extension {
         this.mods_update_id = null;
 
         const settings = this.getSettings();
-        MODIFIERS = [];
-        for (const item of settings.get_strv('modifier-mapping')) {
-            const [name, sym] = item.split(':');
-            if (MODIFIER_ENUM[name])
-                MODIFIERS.push([MODIFIER_ENUM[name], sym]);
-        }
+        MODIFIERS = [
+            [MODIFIER_ENUM.SHIFT, settings.get_string('shift-symbol')],
+            [MODIFIER_ENUM.LOCK, settings.get_string('caps-symbol')],
+            [MODIFIER_ENUM.CONTROL, settings.get_string('control-symbol')],
+            [MODIFIER_ENUM.MOD1, settings.get_string('mod1-symbol')],
+            [MODIFIER_ENUM.MOD2, settings.get_string('mod2-symbol')],
+            [MODIFIER_ENUM.MOD3, settings.get_string('mod3-symbol')],
+            [MODIFIER_ENUM.MOD4, settings.get_string('mod4-symbol')],
+            [MODIFIER_ENUM.MOD5, settings.get_string('mod5-symbol')],
+        ];
         latch_sym = settings.get_string('latch-symbol');
         lock_sym = settings.get_string('lock-symbol');
         icon = settings.get_string('icon');

--- a/prefs.js
+++ b/prefs.js
@@ -11,22 +11,26 @@ export default class Prefs extends ExtensionPreferences {
     fillPreferencesWindow(window) {
         const page = new Adw.PreferencesPage();
         const group = new Adw.PreferencesGroup({ title: 'Modifier Mapping' });
+        const addMapEntry = (key, title) => {
+            const entry = new Gtk.Entry({ text: this.settings.get_string(key) });
+            entry.connect('changed', () => {
+                this.settings.set_string(key, entry.text);
+            });
+            const row = new Adw.ActionRow({ title });
+            row.add_suffix(entry);
+            row.activatable_widget = entry;
+            group.add(row);
+        };
 
-        const textView = new Gtk.TextView({ monospace: true });
-        const buffer = textView.get_buffer();
-        buffer.text = this.settings.get_strv('modifier-mapping').join('\n');
-        buffer.connect('changed', () => {
-            const text = buffer.text;
-            const lines = text.split('\n').map(l => l.trim()).filter(l => l);
-            this.settings.set_strv('modifier-mapping', lines);
-        });
+        addMapEntry('shift-symbol', 'Shift');
+        addMapEntry('caps-symbol', 'Caps Lock');
+        addMapEntry('control-symbol', 'Control');
+        addMapEntry('mod1-symbol', 'Mod1 / Alt');
+        addMapEntry('mod2-symbol', 'Mod2');
+        addMapEntry('mod3-symbol', 'Mod3');
+        addMapEntry('mod4-symbol', 'Mod4 / Super');
+        addMapEntry('mod5-symbol', 'Mod5');
 
-        const scrolled = new Gtk.ScrolledWindow({ hexpand: true, vexpand: true });
-        scrolled.set_child(textView);
-
-        const row = new Adw.ActionRow({ title: 'Mappings' });
-        row.add_suffix(scrolled);
-        group.add(row);
         page.add(group);
 
         const symbols = new Adw.PreferencesGroup({ title: 'Symbols' });

--- a/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
@@ -1,12 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <schema id="org.gnome.shell.extensions.keyboard-modifiers-status" path="/org/gnome/shell/extensions/keyboard-modifiers-status/">
-    <key name="modifier-mapping" type="as">
-      <default>
-        ['SHIFT:⇧', 'LOCK:⇬', 'CONTROL:⋀', 'MOD1:⌥', 'MOD2:①', 'MOD3:◆', 'MOD4:⌘', 'MOD5:⎇']
-      </default>
-      <summary>Modifier symbol mapping</summary>
-      <description>Array mapping modifier names to symbols using NAME:SYMBOL format.</description>
+    <key name="shift-symbol" type="s">
+      <default>'⇧'</default>
+      <summary>Shift symbol</summary>
+      <description>Symbol displayed when the Shift modifier is active.</description>
+    </key>
+    <key name="caps-symbol" type="s">
+      <default>'⇬'</default>
+      <summary>Caps Lock symbol</summary>
+      <description>Symbol displayed when the Caps Lock modifier is active.</description>
+    </key>
+    <key name="control-symbol" type="s">
+      <default>'⋀'</default>
+      <summary>Control symbol</summary>
+      <description>Symbol displayed when the Control modifier is active.</description>
+    </key>
+    <key name="mod1-symbol" type="s">
+      <default>'⌥'</default>
+      <summary>Mod1 symbol</summary>
+      <description>Symbol displayed when the Mod1/Alt modifier is active.</description>
+    </key>
+    <key name="mod2-symbol" type="s">
+      <default>'①'</default>
+      <summary>Mod2 symbol</summary>
+      <description>Symbol displayed when the Mod2 modifier is active.</description>
+    </key>
+    <key name="mod3-symbol" type="s">
+      <default>'◆'</default>
+      <summary>Mod3 symbol</summary>
+      <description>Symbol displayed when the Mod3 modifier is active.</description>
+    </key>
+    <key name="mod4-symbol" type="s">
+      <default>'⌘'</default>
+      <summary>Mod4 symbol</summary>
+      <description>Symbol displayed when the Mod4/Super modifier is active.</description>
+    </key>
+    <key name="mod5-symbol" type="s">
+      <default>'⎇'</default>
+      <summary>Mod5 symbol</summary>
+      <description>Symbol displayed when the Mod5 modifier is active.</description>
     </key>
     <key name="latch-symbol" type="s">
       <default>'\''</default>


### PR DESCRIPTION
## Summary
- split modifier list into dedicated keys in schema
- use new modifier symbol keys in extension
- update preferences panel for new keys

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bb5fd1f648332a0d57f4b3c8363ee