### PR TITLE
Rename schema keys

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -183,17 +183,17 @@ export default class KMS extends Extension {
             [MODIFIER_ENUM.SHIFT, this._settings.get_string('shift-symbol')],
             [MODIFIER_ENUM.LOCK, this._settings.get_string('caps-symbol')],
             [MODIFIER_ENUM.CONTROL, this._settings.get_string('control-symbol')],
-            [MODIFIER_ENUM.MOD1, this._settings.get_string('mod1-symbol')],
-            [MODIFIER_ENUM.MOD2, this._settings.get_string('mod2-symbol')],
-            [MODIFIER_ENUM.MOD3, this._settings.get_string('mod3-symbol')],
-            [MODIFIER_ENUM.MOD4, this._settings.get_string('mod4-symbol')],
-            [MODIFIER_ENUM.MOD5, this._settings.get_string('mod5-symbol')],
+            [MODIFIER_ENUM.MOD1, this._settings.get_string('alt-symbol')],
+            [MODIFIER_ENUM.MOD2, this._settings.get_string('num-symbol')],
+            [MODIFIER_ENUM.MOD3, this._settings.get_string('scroll-symbol')],
+            [MODIFIER_ENUM.MOD4, this._settings.get_string('super-symbol')],
+            [MODIFIER_ENUM.MOD5, this._settings.get_string('altgr-symbol')],
         ];
         this._symLatch = this._settings.get_string('latch-symbol');
         this._symLock = this._settings.get_string('lock-symbol');
-        this._symIcon = this._settings.get_string('icon');
-        this._symOpening = this._settings.get_string('opening');
-        this._symClosing = this._settings.get_string('closing');
+        this._symIcon = this._settings.get_string('icon-symbol');
+        this._symOpening = this._settings.get_string('opening-symbol');
+        this._symClosing = this._settings.get_string('closing-symbol');
 
         console.debug(`${tag} _loadSettings() ... out`);
     }

--- a/prefs.js
+++ b/prefs.js
@@ -12,9 +12,9 @@ export default class Prefs extends ExtensionPreferences {
 		this._settings = this.getSettings();
 		this._schema = this._settings.settings_schema;
 
-		const modifiersKeys = ['shift-symbol', 'caps-symbol', 'control-symbol', 'mod1-symbol', 'mod2-symbol', 'mod3-symbol', 'mod4-symbol', 'mod5-symbol'];
-		const accessibilityKeys = ['latch-symbol', 'lock-symbol'];
-		const wrapperKeys = ['icon', 'opening', 'closing'];
+                const modifiersKeys = ['shift-symbol', 'caps-symbol', 'control-symbol', 'alt-symbol', 'num-symbol', 'scroll-symbol', 'super-symbol', 'altgr-symbol'];
+                const accessibilityKeys = ['latch-symbol', 'lock-symbol'];
+                const wrapperKeys = ['icon-symbol', 'opening-symbol', 'closing-symbol'];
 		this._currentSymbols = this._getSchemaModifierSymbols([].concat(modifiersKeys, accessibilityKeys, wrapperKeys));
 		console.debug(`${tag} this._currentSymbols: ${this._currentSymbols}`);
 

--- a/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.keyboard-modifiers-status.gschema.xml
@@ -16,30 +16,30 @@
       <summary>Control symbol</summary>
       <description>Symbol displayed when the Control modifier is active.</description>
     </key>
-    <key name="mod1-symbol" type="s">
+    <key name="alt-symbol" type="s">
       <default>'⌥'</default>
-      <summary>Mod1/Alt symbol</summary>
-      <description>Symbol displayed when the Mod1/Alt modifier is active.</description>
+      <summary>Alt symbol</summary>
+      <description>Symbol displayed when the Alt modifier is active.</description>
     </key>
-    <key name="mod2-symbol" type="s">
+    <key name="num-symbol" type="s">
       <default>'①'</default>
-      <summary>Mod2/Num Lock symbol</summary>
-			<description>Symbol displayed when the Mod2/Num Lock modifier is active.</description>
+      <summary>Num Lock symbol</summary>
+                        <description>Symbol displayed when the Num Lock modifier is active.</description>
     </key>
-    <key name="mod3-symbol" type="s">
+    <key name="scroll-symbol" type="s">
       <default>'◆'</default>
-			<summary>Mod3/Scroll Lock symbol</summary>
-			<description>Symbol displayed when the Mod3/Scroll Lock modifier is active.</description>
+                        <summary>Scroll Lock symbol</summary>
+                        <description>Symbol displayed when the Scroll Lock modifier is active.</description>
     </key>
-    <key name="mod4-symbol" type="s">
+    <key name="super-symbol" type="s">
       <default>'⌘'</default>
-			<summary>Mod4/Super symbol</summary>
-      <description>Symbol displayed when the Mod4/Super modifier is active.</description>
+                        <summary>Super symbol</summary>
+      <description>Symbol displayed when the Super modifier is active.</description>
     </key>
-    <key name="mod5-symbol" type="s">
+    <key name="altgr-symbol" type="s">
       <default>'⎇'</default>
-      <summary>Mod5/AltGr symbol</summary>
-			<description>Symbol displayed when the Mod5/AltGr modifier is active.</description>
+      <summary>AltGr symbol</summary>
+                        <description>Symbol displayed when the AltGr modifier is active.</description>
     </key>
     <key name="latch-symbol" type="s">
       <default>'\''</default>
@@ -51,19 +51,19 @@
       <summary>Lock symbol</summary>
       <description>Symbol displayed when a modifier is locked.</description>
     </key>
-    <key name="icon" type="s">
+    <key name="icon-symbol" type="s">
       <default>''</default>
       <summary>Prefix icon</summary>
       <description>Optional symbol shown before the modifier list.</description>
     </key>
-    <key name="opening" type="s">
+    <key name="opening-symbol" type="s">
       <default>''</default>
-      <summary>Opening text</summary>
+      <summary>Opening symbol</summary>
       <description>String placed before the modifier state display.</description>
     </key>
-    <key name="closing" type="s">
+    <key name="closing-symbol" type="s">
       <default>''</default>
-      <summary>Closing text</summary>
+      <summary>Closing symbol</summary>
       <description>String placed after the modifier state display.</description>
     </key>
   </schema>


### PR DESCRIPTION
## Summary
- rename key names for modifiers to descriptive names
- adjust code to read new schema keys
- rename opening/closing to opening-symbol/closing-symbol

## Testing
- `make test` *(fails: gjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584306d6408332aafa14a60b74b2f9